### PR TITLE
Added missing parameter in function call

### DIFF
--- a/src/pedersen_printbases.js
+++ b/src/pedersen_printbases.js
@@ -18,7 +18,7 @@ async function run() {
     }
 
     for (let i=0; i < nBases; i++) {
-        const p = pedersenHash.getBasePoint(i);
+        const p = pedersenHash.getBasePoint(baseHash, i);
         console.log(`[${pedersenHash.babyJub.F.toString(p[0])},${pedersenHash.babyJub.F.toString(p[1])}]`);
     }
 


### PR DESCRIPTION
The getBasePoint function takes the hash type and the point index, however is only supplied the index here, causing a crash when this is executed. Added the hash type to fix this.