### PR TITLE
bump ffjavascript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "blake-hash": "^2.0.0",
         "blake2b": "^2.1.3",
         "ethers": "^5.5.1",
-        "ffjavascript": "^0.2.45"
+        "ffjavascript": "^0.2.55"
       },
       "devDependencies": {
         "chai": "^4.3.4",

--- a/package.json
+++ b/package.json
@@ -42,6 +42,6 @@
     "blake-hash": "^2.0.0",
     "blake2b": "^2.1.3",
     "ethers": "^5.5.1",
-    "ffjavascript": "^0.2.45"
+    "ffjavascript": "^0.2.55"
   }
 }


### PR DESCRIPTION
This upgrades the ffjavascript version. 

Currently `circomlibjs` is using an outdated version of ffjavascript which fails to build poseidon. 

See https://github.com/iden3/circomlibjs/issues/2 for more details.