### PR TITLE
Switch from blake-hash and blake2b to audited noble-hashes

### DIFF
--- a/build/main.cjs
+++ b/build/main.cjs
@@ -1,18 +1,10 @@
 'use strict';
 
-Object.defineProperty(exports, '__esModule', { value: true });
-
 var ffjavascript = require('ffjavascript');
-var blake2b = require('blake2b');
-var createBlakeHash = require('blake-hash');
+var blake1 = require('@noble/hashes/blake1');
 var ethers = require('ethers');
+var blake2b = require('@noble/hashes/blake2b');
 var assert = require('assert');
-
-function _interopDefaultLegacy (e) { return e && typeof e === 'object' && 'default' in e ? e : { 'default': e }; }
-
-var blake2b__default = /*#__PURE__*/_interopDefaultLegacy(blake2b);
-var createBlakeHash__default = /*#__PURE__*/_interopDefaultLegacy(createBlakeHash);
-var assert__default = /*#__PURE__*/_interopDefaultLegacy(assert);
 
 async function buildBabyJub() {
     const bn128 = await ffjavascript.getCurveFromName("bn128", true);
@@ -152,6 +144,176 @@ class BabyJub {
     }
 }
 
+const SEED$1 = "mimc";
+const NROUNDS$1 = 91;
+
+async function buildMimc7() {
+    const bn128 = await ffjavascript.getCurveFromName("bn128", true);
+    return new Mimc7(bn128.Fr);
+}
+
+
+class Mimc7 {
+    constructor (F) {
+        this.F = F;
+        this.cts = this.getConstants(SEED$1, 91);
+    }
+
+    getIV(seed) {
+        const F = this.F;
+        if (typeof seed === "undefined") seed = SEED$1;
+        const c = ethers.ethers.utils.keccak256(ethers.ethers.utils.toUtf8Bytes(seed+"_iv"));
+        const cn = ffjavascript.Scalar.e(c);
+        const iv = ffjavascript.Scalar.mod(cn, F.p);
+        return iv;
+    };
+
+    getConstants(seed, nRounds) {
+        const F = this.F;
+        if (typeof nRounds === "undefined") nRounds = NROUNDS$1;
+        const cts = new Array(nRounds);
+        let c = ethers.ethers.utils.keccak256(ethers.ethers.utils.toUtf8Bytes(SEED$1));
+        for (let i=1; i<nRounds; i++) {
+            c = ethers.ethers.utils.keccak256(c);
+
+            cts[i] = F.e(c);
+        }
+        cts[0] = F.e(0);
+        return cts;
+    }
+
+    hash (_x_in, _k) {
+        const F = this.F;
+        const x_in = F.e(_x_in);
+        const k = F.e(_k);
+        let r;
+        for (let i=0; i<NROUNDS$1; i++) {
+            const c = this.cts[i];
+            const t = (i==0) ? F.add(x_in, k) : F.add(F.add(r, k), c);
+            const t2 = F.square(t);
+            const t4 = F.square(t2);
+            r = F.mul(F.mul(t4, t2), t);
+        }
+        return F.add(r, k);
+    }
+
+    multiHash(arr, key) {
+        const F = this.F;
+        let r;
+        if (typeof(key) === "undefined") {
+            r = F.zero;
+        } else {
+            r = F.e(key);
+        }
+        for (let i=0; i<arr.length; i++) {
+            r = F.add(
+                F.add(
+                    r,
+                    F.e(arr[i])
+                ),
+                this.hash(F.e(arr[i]), r)
+            );
+        }
+        return r;
+    }
+}
+
+const SEED = "mimcsponge";
+const NROUNDS = 220;
+
+async function buildMimcSponge() {
+    const bn128 = await ffjavascript.getCurveFromName("bn128", true);
+    return new MimcSponge(bn128.Fr);
+}
+
+class MimcSponge {
+    constructor (F) {
+        this.F = F;
+        this.cts = this.getConstants(SEED, NROUNDS);
+    }
+
+    getIV (seed)  {
+        const F = this.F;
+        if (typeof seed === "undefined") seed = SEED;
+        const c = ethers.ethers.utils.keccak256(ethers.ethers.utils.toUtf8Bytes(seed+"_iv"));
+        const cn = ffjavascript.Scalar.e(c);
+        const iv = cn.mod(F.p);
+        return iv;
+    };
+
+    getConstants (seed, nRounds)  {
+        const F = this.F;
+        if (typeof nRounds === "undefined") nRounds = NROUNDS;
+        const cts = new Array(nRounds);
+        let c = ethers.ethers.utils.keccak256(ethers.ethers.utils.toUtf8Bytes(SEED));        for (let i=1; i<nRounds; i++) {
+            c = ethers.ethers.utils.keccak256(c);
+
+            cts[i] = F.e(c);
+        }
+        cts[0] = F.e(0);
+        cts[cts.length - 1] = F.e(0);
+        return cts;
+    };
+
+
+    hash(_xL_in, _xR_in, _k) {
+        const F = this.F;
+        let xL = F.e(_xL_in);
+        let xR = F.e(_xR_in);
+        const k = F.e(_k);
+        for (let i=0; i<NROUNDS; i++) {
+            const c = this.cts[i];
+            const t = (i==0) ? F.add(xL, k) : F.add(F.add(xL, k), c);
+            const t2 = F.square(t);
+            const t4 = F.square(t2);
+            const t5 = F.mul(t4, t);
+            const xR_tmp = F.e(xR);
+            if (i < (NROUNDS - 1)) {
+                xR = xL;
+                xL = F.add(xR_tmp, t5);
+            } else {
+                xR = F.add(xR_tmp, t5);
+            }
+        }
+        return {
+            xL: xL,
+            xR: xR
+        };
+    }
+
+    multiHash(arr, key, numOutputs)  {
+        const F = this.F;
+        if (typeof(numOutputs) === "undefined") {
+            numOutputs = 1;
+        }
+        if (typeof(key) === "undefined") {
+            key = F.zero;
+        }
+
+        let R = F.zero;
+        let C = F.zero;
+
+        for (let i=0; i<arr.length; i++) {
+            R = F.add(R, F.e(arr[i]));
+            const S = this.hash(R, C, key);
+            R = S.xL;
+            C = S.xR;
+        }
+        let outputs = [R];
+        for (let i=1; i < numOutputs; i++) {
+            const S = this.hash(R, C, key);
+            R = S.xL;
+            C = S.xR;
+            outputs.push(R);
+        }
+        if (numOutputs == 1) {
+            return outputs[0];
+        } else {
+            return outputs;
+        }
+    }
+}
+
 const GENPOINT_PREFIX = "PedersenGenerator";
 const windowSize = 4;
 const nWindowsPerSegment = 50;
@@ -170,9 +332,9 @@ class PedersenHash {
 
     baseHash(type, S) {
         if (type == "blake") {
-            return createBlakeHash__default["default"]("blake256").update(S).digest();
+            return Buffer.from(blake1.blake256(S));
         } else if (type == "blake2b") {
-            return Buffer.from(blake2b__default["default"](32).update(Buffer.from(S)).digest());
+            return Buffer.from(blake2b.blake2b(Buffer.from(S)));
         }
     }
 
@@ -272,80 +434,6 @@ class PedersenHash {
             res[i*8+7] = (b & 0x80) >> 7;
         }
         return res;
-    }
-}
-
-const SEED$1 = "mimc";
-const NROUNDS$1 = 91;
-
-async function buildMimc7() {
-    const bn128 = await ffjavascript.getCurveFromName("bn128", true);
-    return new Mimc7(bn128.Fr);
-}
-
-
-class Mimc7 {
-    constructor (F) {
-        this.F = F;
-        this.cts = this.getConstants(SEED$1, 91);
-    }
-
-    getIV(seed) {
-        const F = this.F;
-        if (typeof seed === "undefined") seed = SEED$1;
-        const c = ethers.ethers.utils.keccak256(ethers.ethers.utils.toUtf8Bytes(seed+"_iv"));
-        const cn = ffjavascript.Scalar.e(c);
-        const iv = ffjavascript.Scalar.mod(cn, F.p);
-        return iv;
-    };
-
-    getConstants(seed, nRounds) {
-        const F = this.F;
-        if (typeof nRounds === "undefined") nRounds = NROUNDS$1;
-        const cts = new Array(nRounds);
-        let c = ethers.ethers.utils.keccak256(ethers.ethers.utils.toUtf8Bytes(SEED$1));
-        for (let i=1; i<nRounds; i++) {
-            c = ethers.ethers.utils.keccak256(c);
-
-            cts[i] = F.e(c);
-        }
-        cts[0] = F.e(0);
-        return cts;
-    }
-
-    hash (_x_in, _k) {
-        const F = this.F;
-        const x_in = F.e(_x_in);
-        const k = F.e(_k);
-        let r;
-        for (let i=0; i<NROUNDS$1; i++) {
-            const c = this.cts[i];
-            const t = (i==0) ? F.add(x_in, k) : F.add(F.add(r, k), c);
-            const t2 = F.square(t);
-            const t4 = F.square(t2);
-            r = F.mul(F.mul(t4, t2), t);
-        }
-        return F.add(r, k);
-    }
-
-    multiHash(arr, key) {
-        const F = this.F;
-        let r;
-        if (typeof(key) === "undefined") {
-            r = F.zero;
-        } else {
-            r = F.e(key);
-        }
-        for (let i=0; i<arr.length; i++) {
-            r = F.add(
-                F.add(
-                    r,
-                    F.e(arr[i])
-                ),
-                this.hash(F.e(arr[i]), r)
-            );
-        }
-        return r;
     }
 }
 
@@ -25585,102 +25673,6 @@ function buildPoseidonWasm(module) {
     module.exportFunction("poseidon");
 }
 
-const SEED = "mimcsponge";
-const NROUNDS = 220;
-
-async function buildMimcSponge() {
-    const bn128 = await ffjavascript.getCurveFromName("bn128", true);
-    return new MimcSponge(bn128.Fr);
-}
-
-class MimcSponge {
-    constructor (F) {
-        this.F = F;
-        this.cts = this.getConstants(SEED, NROUNDS);
-    }
-
-    getIV (seed)  {
-        const F = this.F;
-        if (typeof seed === "undefined") seed = SEED;
-        const c = ethers.ethers.utils.keccak256(ethers.ethers.utils.toUtf8Bytes(seed+"_iv"));
-        const cn = ffjavascript.Scalar.e(c);
-        const iv = cn.mod(F.p);
-        return iv;
-    };
-
-    getConstants (seed, nRounds)  {
-        const F = this.F;
-        if (typeof nRounds === "undefined") nRounds = NROUNDS;
-        const cts = new Array(nRounds);
-        let c = ethers.ethers.utils.keccak256(ethers.ethers.utils.toUtf8Bytes(SEED));        for (let i=1; i<nRounds; i++) {
-            c = ethers.ethers.utils.keccak256(c);
-
-            cts[i] = F.e(c);
-        }
-        cts[0] = F.e(0);
-        cts[cts.length - 1] = F.e(0);
-        return cts;
-    };
-
-
-    hash(_xL_in, _xR_in, _k) {
-        const F = this.F;
-        let xL = F.e(_xL_in);
-        let xR = F.e(_xR_in);
-        const k = F.e(_k);
-        for (let i=0; i<NROUNDS; i++) {
-            const c = this.cts[i];
-            const t = (i==0) ? F.add(xL, k) : F.add(F.add(xL, k), c);
-            const t2 = F.square(t);
-            const t4 = F.square(t2);
-            const t5 = F.mul(t4, t);
-            const xR_tmp = F.e(xR);
-            if (i < (NROUNDS - 1)) {
-                xR = xL;
-                xL = F.add(xR_tmp, t5);
-            } else {
-                xR = F.add(xR_tmp, t5);
-            }
-        }
-        return {
-            xL: xL,
-            xR: xR
-        };
-    }
-
-    multiHash(arr, key, numOutputs)  {
-        const F = this.F;
-        if (typeof(numOutputs) === "undefined") {
-            numOutputs = 1;
-        }
-        if (typeof(key) === "undefined") {
-            key = F.zero;
-        }
-
-        let R = F.zero;
-        let C = F.zero;
-
-        for (let i=0; i<arr.length; i++) {
-            R = F.add(R, F.e(arr[i]));
-            const S = this.hash(R, C, key);
-            R = S.xL;
-            C = S.xR;
-        }
-        let outputs = [R];
-        for (let i=1; i < numOutputs; i++) {
-            const S = this.hash(R, C, key);
-            R = S.xL;
-            C = S.xR;
-            outputs.push(R);
-        }
-        if (numOutputs == 1) {
-            return outputs[0];
-        } else {
-            return outputs;
-        }
-    }
-}
-
 async function buildEddsa() {
     const babyJub = await buildBabyJub();
     const pedersenHash = await buildPedersenHash();
@@ -25710,7 +25702,7 @@ class Eddsa {
 
     prv2pub(prv) {
         this.babyJub.F;
-        const sBuff = this.pruneBuffer(createBlakeHash__default["default"]("blake512").update(Buffer.from(prv)).digest());
+        const sBuff = this.pruneBuffer(blake1.blake512(Buffer.from(prv)));
         let s = ffjavascript.Scalar.fromRprLE(sBuff, 0, 32);
         const A = this.babyJub.mulPointEscalar(this.babyJub.Base8, ffjavascript.Scalar.shr(s,3));
         return A;
@@ -25718,14 +25710,14 @@ class Eddsa {
 
     signPedersen(prv, msg) {
         this.babyJub.F;
-        const sBuff = this.pruneBuffer(createBlakeHash__default["default"]("blake512").update(Buffer.from(prv)).digest());
+        const sBuff = this.pruneBuffer(blake1.blake512(Buffer.from(prv)));
         const s = ffjavascript.Scalar.fromRprLE(sBuff, 0, 32);
         const A = this.babyJub.mulPointEscalar(this.babyJub.Base8, ffjavascript.Scalar.shr(s, 3));
 
         const composeBuff = new Uint8Array(32 + msg.length);
         composeBuff.set(sBuff.slice(32), 0);
         composeBuff.set(msg, 32);
-        const rBuff = createBlakeHash__default["default"]("blake512").update(Buffer.from(composeBuff)).digest();
+        const rBuff = blake1.blake512(Buffer.from(composeBuff));
         let r = ffjavascript.Scalar.mod(ffjavascript.Scalar.fromRprLE(rBuff, 0, 64), this.babyJub.subOrder);
         const R8 = this.babyJub.mulPointEscalar(this.babyJub.Base8, r);
         const R8p = this.babyJub.packPoint(R8);
@@ -25754,7 +25746,7 @@ class Eddsa {
 
     signMiMC(prv, msg) {
         const F = this.babyJub.F;
-        const sBuff = this.pruneBuffer(createBlakeHash__default["default"]("blake512").update(Buffer.from(prv)).digest());
+        const sBuff = this.pruneBuffer(blake1.blake512(Buffer.from(prv)));
         const s = ffjavascript.Scalar.fromRprLE(sBuff, 0, 32);
         const A = this.babyJub.mulPointEscalar(this.babyJub.Base8, ffjavascript.Scalar.shr(s, 3));
 
@@ -25762,7 +25754,7 @@ class Eddsa {
         const composeBuff = new Uint8Array(32 + msg.length);
         composeBuff.set(sBuff.slice(32), 0);
         F.toRprLE(composeBuff, 32, msg);
-        const rBuff = createBlakeHash__default["default"]("blake512").update(Buffer.from(composeBuff)).digest();
+        const rBuff = blake1.blake512(Buffer.from(composeBuff));
         let r = ffjavascript.Scalar.mod(ffjavascript.Scalar.fromRprLE(rBuff, 0, 64), this.babyJub.subOrder);
         const R8 = this.babyJub.mulPointEscalar(this.babyJub.Base8, r);
 
@@ -25783,14 +25775,14 @@ class Eddsa {
 
     signMiMCSponge(prv, msg) {
         const F = this.babyJub.F;
-        const sBuff = this.pruneBuffer(createBlakeHash__default["default"]("blake512").update(Buffer.from(prv)).digest());
+        const sBuff = this.pruneBuffer(blake1.blake512(Buffer.from(prv)));
         const s = ffjavascript.Scalar.fromRprLE(sBuff, 0, 32);
         const A = this.babyJub.mulPointEscalar(this.babyJub.Base8, ffjavascript.Scalar.shr(s, 3));
 
         const composeBuff = new Uint8Array(32 + msg.length);
         composeBuff.set(sBuff.slice(32), 0);
         F.toRprLE(composeBuff, 32, msg);
-        const rBuff = createBlakeHash__default["default"]("blake512").update(Buffer.from(composeBuff)).digest();
+        const rBuff = blake1.blake512(Buffer.from(composeBuff));
         let r = ffjavascript.Scalar.mod(ffjavascript.Scalar.fromRprLE(rBuff, 0, 64), this.babyJub.subOrder);
         const R8 = this.babyJub.mulPointEscalar(this.babyJub.Base8, r);
 
@@ -25811,14 +25803,14 @@ class Eddsa {
 
     signPoseidon(prv, msg) {
         const F = this.babyJub.F;
-        const sBuff = this.pruneBuffer(createBlakeHash__default["default"]("blake512").update(Buffer.from(prv)).digest());
+        const sBuff = this.pruneBuffer(blake1.blake512(Buffer.from(prv)));
         const s = ffjavascript.Scalar.fromRprLE(sBuff, 0, 32);
         const A = this.babyJub.mulPointEscalar(this.babyJub.Base8, ffjavascript.Scalar.shr(s, 3));
 
         const composeBuff = new Uint8Array(32 + msg.length);
         composeBuff.set(sBuff.slice(32), 0);
         F.toRprLE(composeBuff, 32, msg);
-        const rBuff = createBlakeHash__default["default"]("blake512").update(Buffer.from(composeBuff)).digest();
+        const rBuff = blake1.blake512(Buffer.from(composeBuff));
         let r = ffjavascript.Scalar.mod(ffjavascript.Scalar.fromRprLE(rBuff, 0, 64), this.babyJub.subOrder);
         const R8 = this.babyJub.mulPointEscalar(this.babyJub.Base8, r);
 
@@ -25958,6 +25950,9 @@ class Eddsa {
 }
 
 // Copyright (c) 2018 Jordi Baylina
+// License: LGPL-3.0+
+//
+
 
 class Contract {
     constructor() {
@@ -26161,6 +26156,9 @@ class Contract {
 }
 
 // Copyright (c) 2018 Jordi Baylina
+// License: LGPL-3.0+
+//
+
 
 function createCode$2(seed, n) {
 
@@ -26266,11 +26264,14 @@ const abi$1 = [
 
 var _mimc7Contract = /*#__PURE__*/Object.freeze({
     __proto__: null,
-    createCode: createCode$2,
-    abi: abi$1
+    abi: abi$1,
+    createCode: createCode$2
 });
 
 // Copyright (c) 2018 Jordi Baylina
+// License: LGPL-3.0+
+//
+
 
 function createCode$1(seed, n) {
 
@@ -26391,8 +26392,8 @@ const abi = [
 
 var _mimcSpongeContract = /*#__PURE__*/Object.freeze({
     __proto__: null,
-    createCode: createCode$1,
-    abi: abi
+    abi: abi,
+    createCode: createCode$1
 });
 
 var poseidonConstants = {
@@ -26603,6 +26604,9 @@ var poseidonConstants = {
   };
 
 // Copyright (c) 2018 Jordi Baylina
+// License: LGPL-3.0+
+//
+
 const { unstringifyBigInts } = ffjavascript.utils;
 
 const { C:K, M } = unstringifyBigInts(poseidonConstants);
@@ -26845,8 +26849,8 @@ async function buildPoseidon$1() {
     const pow5 = a => F.mul(a, F.square(F.square(a, a)));
 
     function poseidon(inputs, initState, nOut) {
-        assert__default["default"](inputs.length > 0);
-        assert__default["default"](inputs.length <= N_ROUNDS_P.length);
+        assert(inputs.length > 0);
+        assert(inputs.length <= N_ROUNDS_P.length);
 
         const t = inputs.length + 1;
         const nRoundsF = N_ROUNDS_F;
@@ -26885,6 +26889,8 @@ async function buildPoseidon$1() {
 }
 
 // Parameters are generated by a reference script https://extgit.iaik.tugraz.at/krypto/hadeshash/-/blob/master/code/generate_parameters_grain.sage
+// Used like so: sage generate_parameters_grain.sage 1 0 254 2 8 56 0x30644e72e131a029b85045b68181585d2833e84879b9709143e1f593f0000001
+
 
 function unsringifyConstants(Fr, o) {
     if ((typeof(o) == "string") && (/^[0-9]+$/.test(o) ))  {
@@ -26919,8 +26925,8 @@ async function buildPoseidon() {
     const pow5 = a => F.mul(a, F.square(F.square(a, a)));
 
     function poseidon(inputs, initState, nOut) {
-        assert__default["default"](inputs.length > 0);
-        assert__default["default"](inputs.length <= N_ROUNDS_P.length);
+        assert(inputs.length > 0);
+        assert(inputs.length <= N_ROUNDS_P.length);
 
         if (initState) {
             initState = F.e(initState);

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,8 +10,6 @@
       "license": "GPL-3.0",
       "dependencies": {
         "@noble/hashes": "^1.7.1",
-        "blake-hash": "^2.0.0",
-        "blake2b": "^2.1.3",
         "ethers": "^5.5.1",
         "ffjavascript": "^0.3.0"
       },
@@ -775,11 +773,6 @@
         "node": "*"
       }
     },
-    "node_modules/b4a": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.5.3.tgz",
-      "integrity": "sha512-1aCQIzQJK7G0z1Una75tWMlwVAR8o+QHoAlnWc5XAxRVBESY9WsitfBgM5nPyDBP5HrhPU1Np4Pq2Y7CJQ+tVw=="
-    },
     "node_modules/balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -798,38 +791,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/blake-hash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/blake-hash/-/blake-hash-2.0.0.tgz",
-      "integrity": "sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w==",
-      "hasInstallScript": true,
-      "dependencies": {
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.2",
-        "readable-stream": "^3.6.0"
-      },
-      "engines": {
-        "node": ">= 10"
-      }
-    },
-    "node_modules/blake2b": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
-      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
-      "dependencies": {
-        "blake2b-wasm": "^2.4.0",
-        "nanoassert": "^2.0.0"
-      }
-    },
-    "node_modules/blake2b-wasm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
-      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
-      "dependencies": {
-        "b4a": "^1.0.1",
-        "nanoassert": "^2.0.0"
       }
     },
     "node_modules/bn.js": {
@@ -2007,11 +1968,6 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "node_modules/nanoassert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
-      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
-    },
     "node_modules/nanoid": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
@@ -2022,21 +1978,6 @@
       },
       "engines": {
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
-      }
-    },
-    "node_modules/node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
-    },
-    "node_modules/node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ==",
-      "bin": {
-        "node-gyp-build": "bin.js",
-        "node-gyp-build-optional": "optional.js",
-        "node-gyp-build-test": "build-test.js"
       }
     },
     "node_modules/normalize-path": {
@@ -2135,19 +2076,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "node_modules/readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "dependencies": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      },
-      "engines": {
-        "node": ">= 6"
-      }
-    },
     "node_modules/readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -2173,6 +2101,7 @@
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
       "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -2200,14 +2129,6 @@
       "dev": true,
       "dependencies": {
         "randombytes": "^2.1.0"
-      }
-    },
-    "node_modules/string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "dependencies": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "node_modules/string-width": {
@@ -2283,11 +2204,6 @@
       "engines": {
         "node": ">=4"
       }
-    },
-    "node_modules/util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/wasmbuilder": {
       "version": "0.0.16",
@@ -2865,11 +2781,6 @@
       "integrity": "sha512-jgsaNduz+ndvGyFt3uSuWqvy4lCnIJiovtouQN5JZHOKCS2QuhEdbcQHFhVksz2N2U9hXJo8odG7ETyWlEeuDw==",
       "dev": true
     },
-    "b4a": {
-      "version": "1.5.3",
-      "resolved": "https://registry.npmjs.org/b4a/-/b4a-1.5.3.tgz",
-      "integrity": "sha512-1aCQIzQJK7G0z1Una75tWMlwVAR8o+QHoAlnWc5XAxRVBESY9WsitfBgM5nPyDBP5HrhPU1Np4Pq2Y7CJQ+tVw=="
-    },
     "balanced-match": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
@@ -2886,34 +2797,6 @@
       "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.2.0.tgz",
       "integrity": "sha512-jDctJ/IVQbZoJykoeHbhXpOlNBqGNcwXJKJog42E5HDPUwQTSdjCHdihjj0DlnheQ7blbT6dHOafNAiS8ooQKA==",
       "dev": true
-    },
-    "blake-hash": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/blake-hash/-/blake-hash-2.0.0.tgz",
-      "integrity": "sha512-Igj8YowDu1PRkRsxZA7NVkdFNxH5rKv5cpLxQ0CVXSIA77pVYwCPRQJ2sMew/oneUpfuYRyjG6r8SmmmnbZb1w==",
-      "requires": {
-        "node-addon-api": "^3.0.0",
-        "node-gyp-build": "^4.2.2",
-        "readable-stream": "^3.6.0"
-      }
-    },
-    "blake2b": {
-      "version": "2.1.4",
-      "resolved": "https://registry.npmjs.org/blake2b/-/blake2b-2.1.4.tgz",
-      "integrity": "sha512-AyBuuJNI64gIvwx13qiICz6H6hpmjvYS5DGkG6jbXMOT8Z3WUJ3V1X0FlhIoT1b/5JtHE3ki+xjtMvu1nn+t9A==",
-      "requires": {
-        "blake2b-wasm": "^2.4.0",
-        "nanoassert": "^2.0.0"
-      }
-    },
-    "blake2b-wasm": {
-      "version": "2.4.0",
-      "resolved": "https://registry.npmjs.org/blake2b-wasm/-/blake2b-wasm-2.4.0.tgz",
-      "integrity": "sha512-S1kwmW2ZhZFFFOghcx73+ZajEfKBqhP82JMssxtLVMxlaPea1p9uoLiUZ5WYyHn0KddwbLc+0vh4wR0KBNoT5w==",
-      "requires": {
-        "b4a": "^1.0.1",
-        "nanoassert": "^2.0.0"
-      }
     },
     "bn.js": {
       "version": "5.2.1",
@@ -3769,26 +3652,11 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
-    "nanoassert": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-2.0.0.tgz",
-      "integrity": "sha512-7vO7n28+aYO4J+8w96AzhmU8G+Y/xpPDJz/se19ICsqj/momRbb9mh9ZUtkoJ5X3nTnPdhEJyc0qnM6yAsHBaA=="
-    },
     "nanoid": {
       "version": "3.3.1",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.1.tgz",
       "integrity": "sha512-n6Vs/3KGyxPQd6uO0eH4Bv0ojGSUvuLlIHtC3Y0kEO23YRge8H9x1GCzLn28YX0H66pMkxuaeESFq4tKISKwdw==",
       "dev": true
-    },
-    "node-addon-api": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-3.2.1.tgz",
-      "integrity": "sha512-mmcei9JghVNDYydghQmeDX8KoAm0FAiYyIcUt/N4nhyAipB17pllZQDOJD2fotxABnt4Mdz+dKTO7eftLg4d0A=="
-    },
-    "node-gyp-build": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.4.0.tgz",
-      "integrity": "sha512-amJnQCcgtRVw9SvoebO3BKGESClrfXGCUTX9hSn1OuGQTQBOZmVd0Z0OlecpuRksKvbsUqALE8jls/ErClAPuQ=="
     },
     "normalize-path": {
       "version": "3.0.0",
@@ -3856,16 +3724,6 @@
         "safe-buffer": "^5.1.0"
       }
     },
-    "readable-stream": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-      "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-      "requires": {
-        "inherits": "^2.0.3",
-        "string_decoder": "^1.1.1",
-        "util-deprecate": "^1.0.1"
-      }
-    },
     "readdirp": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-3.6.0.tgz",
@@ -3884,7 +3742,8 @@
     "safe-buffer": {
       "version": "5.2.1",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
-      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "dev": true
     },
     "scrypt-js": {
       "version": "3.0.1",
@@ -3898,14 +3757,6 @@
       "dev": true,
       "requires": {
         "randombytes": "^2.1.0"
-      }
-    },
-    "string_decoder": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
-      "integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
-      "requires": {
-        "safe-buffer": "~5.2.0"
       }
     },
     "string-width": {
@@ -3957,11 +3808,6 @@
       "resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
       "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
       "dev": true
-    },
-    "util-deprecate": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "wasmbuilder": {
       "version": "0.0.16",

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.8",
       "license": "GPL-3.0",
       "dependencies": {
+        "@noble/hashes": "^1.7.1",
         "blake-hash": "^2.0.0",
         "blake2b": "^2.1.3",
         "ethers": "^5.5.1",
@@ -688,6 +689,18 @@
         "@ethersproject/logger": "^5.6.0",
         "@ethersproject/properties": "^5.6.0",
         "@ethersproject/strings": "^5.6.1"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ==",
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
       }
     },
     "node_modules/@ungap/promise-all-settled": {
@@ -2792,6 +2805,11 @@
         "@ethersproject/properties": "^5.6.0",
         "@ethersproject/strings": "^5.6.1"
       }
+    },
+    "@noble/hashes": {
+      "version": "1.7.1",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.7.1.tgz",
+      "integrity": "sha512-B8XBPsn4vT/KJAGqDzbwztd+6Yte3P4V7iafm24bxgDe/mlRuK6xmWPuCNrKt2vDafZ8MfJLlchDG/vYafQEjQ=="
     },
     "@ungap/promise-all-settled": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -39,8 +39,7 @@
     "mocha": "^9.1.3"
   },
   "dependencies": {
-    "blake-hash": "^2.0.0",
-    "blake2b": "^2.1.3",
+    "@noble/hashes": "^1.7.1",
     "ethers": "^5.5.1",
     "ffjavascript": "^0.3.0"
   }

--- a/rollup.cjs.config.js
+++ b/rollup.cjs.config.js
@@ -10,6 +10,8 @@ export default {
         format: "cjs",
     },
     external: [
+        "@noble/hashes/blake1",
+        "@noble/hashes/blake2b",
         ...Object.keys(pkg.dependencies),
         ...builtin,
     ]

--- a/src/eddsa.js
+++ b/src/eddsa.js
@@ -1,10 +1,10 @@
+import { blake512 } from "@noble/hashes/blake1";
 import { Scalar } from "ffjavascript";
 import buildBabyJub from "./babyjub.js";
-import buildPedersenHash from "./pedersen_hash.js";
 import buildMimc7 from "./mimc7.js";
-import { buildPoseidon } from "./poseidon_wasm.js";
 import buildMimcSponge from "./mimcsponge.js";
-import createBlakeHash from "blake-hash";
+import buildPedersenHash from "./pedersen_hash.js";
+import { buildPoseidon } from "./poseidon_wasm.js";
 
 export default async function buildEddsa() {
     const babyJub = await buildBabyJub("bn128");
@@ -35,7 +35,7 @@ class Eddsa {
 
     prv2pub(prv) {
         const F = this.babyJub.F;
-        const sBuff = this.pruneBuffer(createBlakeHash("blake512").update(Buffer.from(prv)).digest());
+        const sBuff = this.pruneBuffer(blake512(Buffer.from(prv)));
         let s = Scalar.fromRprLE(sBuff, 0, 32);
         const A = this.babyJub.mulPointEscalar(this.babyJub.Base8, Scalar.shr(s,3));
         return A;
@@ -43,14 +43,14 @@ class Eddsa {
 
     signPedersen(prv, msg) {
         const F = this.babyJub.F;
-        const sBuff = this.pruneBuffer(createBlakeHash("blake512").update(Buffer.from(prv)).digest());
+        const sBuff = this.pruneBuffer(blake512(Buffer.from(prv)));
         const s = Scalar.fromRprLE(sBuff, 0, 32);
         const A = this.babyJub.mulPointEscalar(this.babyJub.Base8, Scalar.shr(s, 3));
 
         const composeBuff = new Uint8Array(32 + msg.length);
         composeBuff.set(sBuff.slice(32), 0);
         composeBuff.set(msg, 32);
-        const rBuff = createBlakeHash("blake512").update(Buffer.from(composeBuff)).digest();
+        const rBuff = blake512(Buffer.from(composeBuff));
         let r = Scalar.mod(Scalar.fromRprLE(rBuff, 0, 64), this.babyJub.subOrder);
         const R8 = this.babyJub.mulPointEscalar(this.babyJub.Base8, r);
         const R8p = this.babyJub.packPoint(R8);
@@ -79,7 +79,7 @@ class Eddsa {
 
     signMiMC(prv, msg) {
         const F = this.babyJub.F;
-        const sBuff = this.pruneBuffer(createBlakeHash("blake512").update(Buffer.from(prv)).digest());
+        const sBuff = this.pruneBuffer(blake512(Buffer.from(prv)));
         const s = Scalar.fromRprLE(sBuff, 0, 32);
         const A = this.babyJub.mulPointEscalar(this.babyJub.Base8, Scalar.shr(s, 3));
 
@@ -87,7 +87,7 @@ class Eddsa {
         const composeBuff = new Uint8Array(32 + msg.length);
         composeBuff.set(sBuff.slice(32), 0);
         F.toRprLE(composeBuff, 32, msg);
-        const rBuff = createBlakeHash("blake512").update(Buffer.from(composeBuff)).digest();
+        const rBuff = blake512(Buffer.from(composeBuff));
         let r = Scalar.mod(Scalar.fromRprLE(rBuff, 0, 64), this.babyJub.subOrder);
         const R8 = this.babyJub.mulPointEscalar(this.babyJub.Base8, r);
 
@@ -108,14 +108,14 @@ class Eddsa {
 
     signMiMCSponge(prv, msg) {
         const F = this.babyJub.F;
-        const sBuff = this.pruneBuffer(createBlakeHash("blake512").update(Buffer.from(prv)).digest());
+        const sBuff = this.pruneBuffer(blake512(Buffer.from(prv)));
         const s = Scalar.fromRprLE(sBuff, 0, 32);
         const A = this.babyJub.mulPointEscalar(this.babyJub.Base8, Scalar.shr(s, 3));
 
         const composeBuff = new Uint8Array(32 + msg.length);
         composeBuff.set(sBuff.slice(32), 0);
         F.toRprLE(composeBuff, 32, msg);
-        const rBuff = createBlakeHash("blake512").update(Buffer.from(composeBuff)).digest();
+        const rBuff = blake512(Buffer.from(composeBuff));
         let r = Scalar.mod(Scalar.fromRprLE(rBuff, 0, 64), this.babyJub.subOrder);
         const R8 = this.babyJub.mulPointEscalar(this.babyJub.Base8, r);
 
@@ -136,14 +136,14 @@ class Eddsa {
 
     signPoseidon(prv, msg) {
         const F = this.babyJub.F;
-        const sBuff = this.pruneBuffer(createBlakeHash("blake512").update(Buffer.from(prv)).digest());
+        const sBuff = this.pruneBuffer(blake512(Buffer.from(prv)));
         const s = Scalar.fromRprLE(sBuff, 0, 32);
         const A = this.babyJub.mulPointEscalar(this.babyJub.Base8, Scalar.shr(s, 3));
 
         const composeBuff = new Uint8Array(32 + msg.length);
         composeBuff.set(sBuff.slice(32), 0);
         F.toRprLE(composeBuff, 32, msg);
-        const rBuff = createBlakeHash("blake512").update(Buffer.from(composeBuff)).digest();
+        const rBuff = blake512(Buffer.from(composeBuff));
         let r = Scalar.mod(Scalar.fromRprLE(rBuff, 0, 64), this.babyJub.subOrder);
         const R8 = this.babyJub.mulPointEscalar(this.babyJub.Base8, r);
 

--- a/src/pedersen_hash.js
+++ b/src/pedersen_hash.js
@@ -1,7 +1,7 @@
-import buildBabyJub from "./babyjub.js";
-import blake2b from "blake2b";
-import createBlakeHash from "blake-hash";
+import { blake256 } from "@noble/hashes/blake1";
+import { blake2b } from "@noble/hashes/blake2b";
 import { Scalar } from "ffjavascript";
+import buildBabyJub from "./babyjub.js";
 
 const GENPOINT_PREFIX = "PedersenGenerator";
 const windowSize = 4;
@@ -21,9 +21,9 @@ class PedersenHash {
 
     baseHash(type, S) {
         if (type == "blake") {
-            return createBlakeHash("blake256").update(S).digest();
+            return Buffer.from(blake256(S));
         } else if (type == "blake2b") {
-            return Buffer.from(blake2b(32).update(Buffer.from(S)).digest());
+            return Buffer.from(blake2b(Buffer.from(S)));
         }
     }
 

--- a/src/testblake.js
+++ b/src/testblake.js
@@ -1,17 +1,8 @@
-import createBlakeHash from 'blake-hash';
-import blake2b from "blake2b";
-
-const msg = (new TextEncoder()).encode("blake256");
-const msgB = Buffer.from(msg)
-
+import { blake256 } from '@noble/hashes/blake1';
+import { blake2b } from '@noble/hashes/blake2b';
 
 const toHexString = bytes =>
   bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
 
-const h1 = createBlakeHash('blake256').digest();
-
-const h2 = blake2b(64).digest();
-
-
-console.log(toHexString(h1));
-console.log(toHexString(h2));
+console.log(toHexString(blake256('')));
+console.log(toHexString(blake2b('')));


### PR DESCRIPTION
noble cryptography (https://github.com/paulmillr/noble-hashes) is high-security, easily auditable set of contained cryptographic libraries and tools. It would be great to use it instead of some unknown library. Benefits:

- Audited, less resources would be necessary for end-users to audit dep trail
- Smaller bundle size
- Is used by millions of users [(see npm)](http://npmjs.com/package/@noble/hashes)
- Since it's everywhere (e.g. in ethers.js), it would get de-duplicated by end-users when two packages depend on noble
- Is actually maintained, has modern features like esm / typescript / bun / deno friendliness

All PRs:

- PR to snarkjs for **only sha3** https://github.com/iden3/snarkjs/pull/546
- PR to snarkjs for **sha3 and blake2** https://github.com/iden3/snarkjs/pull/547
- PR to wasmsnark https://github.com/iden3/wasmsnark/pull/32 
- PR to circomlib https://github.com/iden3/circomlib/pull/119
- PR to circomlibjs https://github.com/iden3/circomlibjs/pull/32
