### PR TITLE
Fix DoS on negative scalar input to mulPointEscalar + EdDSA bounds hardening

### DIFF
--- a/src/babyjub.js
+++ b/src/babyjub.js
@@ -1,4 +1,4 @@
-import { getCurveFromName, Scalar }  from "ffjavascript";
+import { getCurveFromName, Scalar } from "ffjavascript";
 
 export default async function buildBabyJub() {
     const bn128 = await getCurveFromName("bn128", true);
@@ -9,7 +9,7 @@ class BabyJub {
     constructor(F) {
         this.F = F;
         this.p = Scalar.fromString("21888242871839275222246405745257275088548364400416034343698204186575808495617");
-        this.pm1d2 = Scalar.div(Scalar.sub(this.p, Scalar.e(1)),  Scalar.e(2));
+        this.pm1d2 = Scalar.div(Scalar.sub(this.p, Scalar.e(1)), Scalar.e(2));
 
         this.Generator = [
             F.e("995203441582195749578291179787384436505546430278305826713579947235728471134"),
@@ -26,7 +26,7 @@ class BabyJub {
     }
 
 
-    addPoint(a,b) {
+    addPoint(a, b) {
         const F = this.F;
 
         const res = [];
@@ -36,8 +36,8 @@ class BabyJub {
         res[1] = bigInt((a[1]*b[1] - cta*a[0]*b[0]) * bigInt(bigInt("1") - d*a[0]*b[0]*a[1]*b[1]).inverse(q)).affine(q);
         */
 
-        const beta = F.mul(a[0],b[1]);
-        const gamma = F.mul(a[1],b[0]);
+        const beta = F.mul(a[0], b[1]);
+        const gamma = F.mul(a[1], b[0]);
         const delta = F.mul(
             F.sub(a[1], F.mul(this.A, a[0])),
             F.add(b[0], b[1])
@@ -51,7 +51,7 @@ class BabyJub {
         );
 
         res[1] = F.div(
-            F.add(delta, F.sub(F.mul(this.A,beta), gamma)),
+            F.add(delta, F.sub(F.mul(this.A, beta), gamma)),
             F.sub(F.one, dtau)
         );
 
@@ -60,11 +60,16 @@ class BabyJub {
 
     mulPointEscalar(base, e) {
         const F = this.F;
-        let res = [F.e("0"),F.e("1")];
+        let res = [F.e("0"), F.e("1")];
         let rem = e;
         let exp = base;
 
-        while (! Scalar.isZero(rem)) {
+        if (Scalar.lt(rem, Scalar.e(0))) {
+            rem = Scalar.neg(rem);
+            exp = [F.neg(exp[0]), exp[1]];
+        }
+
+        while (!Scalar.isZero(rem)) {
             if (Scalar.isOdd(rem)) {
                 res = this.addPoint(res, exp);
             }
@@ -78,7 +83,7 @@ class BabyJub {
     inSubgroup(P) {
         const F = this.F;
         if (!this.inCurve(P)) return false;
-        const res= this.mulPointEscalar(P, this.subOrder);
+        const res = this.mulPointEscalar(P, this.subOrder);
         return (F.isZero(res[0]) && F.eq(res[1], F.one));
     }
 
@@ -124,7 +129,7 @@ class BabyJub {
         );
 
         const x2h = F.exp(x2, F.half);
-        if (! F.eq(F.one, x2h)) return null;
+        if (!F.eq(F.one, x2h)) return null;
 
         let x = F.sqrt(x2);
 

--- a/src/eddsa.js
+++ b/src/eddsa.js
@@ -171,6 +171,7 @@ class Eddsa {
         if (!Array.isArray(A)) return false;
         if (A.length!= 2) return false;
         if (!this.babyJub.inCurve(A)) return false;
+        if (Scalar.lt(sig.S, Scalar.e(0))) return false;
         if (Scalar.geq(sig.S, this.babyJub.subOrder)) return false;
 
         const R8p = this.babyJub.packPoint(sig.R8);
@@ -204,6 +205,7 @@ class Eddsa {
         if (!Array.isArray(A)) return false;
         if (A.length!= 2) return false;
         if (!this.babyJub.inCurve(A)) return false;
+        if (Scalar.lt(sig.S, Scalar.e(0))) return false;
         if (sig.S>= this.babyJub.subOrder) return false;
 
         const hm = this.mimc7.multiHash([sig.R8[0], sig.R8[1], A[0], A[1], msg]);
@@ -228,6 +230,7 @@ class Eddsa {
         if (!Array.isArray(A)) return false;
         if (A.length!= 2) return false;
         if (!this.babyJub.inCurve(A)) return false;
+        if (Scalar.lt(sig.S, Scalar.e(0))) return false;
         if (sig.S>= this.babyJub.subOrder) return false;
 
         const hm = this.poseidon([sig.R8[0], sig.R8[1], A[0], A[1], msg]);
@@ -252,6 +255,7 @@ class Eddsa {
         if (!Array.isArray(A)) return false;
         if (A.length!= 2) return false;
         if (!this.babyJub.inCurve(A)) return false;
+        if (Scalar.lt(sig.S, Scalar.e(0))) return false;
         if (sig.S>= this.babyJub.subOrder) return false;
 
         const hm = this.mimcSponge.multiHash([sig.R8[0], sig.R8[1], A[0], A[1], msg]);

--- a/test/eddsa.js
+++ b/test/eddsa.js
@@ -181,9 +181,19 @@ describe("EdDSA js test", function () {
         const negSig = { R8: signature.R8, S: Scalar.sub(eddsa.babyJub.subOrder, signature.S) };
         assert.isFalse(eddsa.verifyPoseidon(msg, negSig, pubKey));
 
-        // Raw negative BigInt S — mulPointEscalar must not loop forever.
+        // Raw negative BigInt S must be rejected at the bounds check, before
+        // ever reaching mulPointEscalar. Spy by replacing the primitive with
+        // one that throws — verify must still return false without invoking it.
         const rawNegSig = { R8: signature.R8, S: Scalar.neg(signature.S) };
-        assert.isFalse(eddsa.verifyPoseidon(msg, rawNegSig, pubKey));
+        const originalMul = eddsa.babyJub.mulPointEscalar;
+        eddsa.babyJub.mulPointEscalar = () => {
+            throw new Error("mulPointEscalar must not be reached for negative S");
+        };
+        try {
+            assert.isFalse(eddsa.verifyPoseidon(msg, rawNegSig, pubKey));
+        } finally {
+            eddsa.babyJub.mulPointEscalar = originalMul;
+        }
     });
 
 });

--- a/test/eddsa.js
+++ b/test/eddsa.js
@@ -6,10 +6,10 @@ const assert = chai.assert;
 import buildEddsa from "../src/eddsa.js";
 
 const fromHexString = hexString =>
-  new Uint8Array(hexString.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
+    new Uint8Array(hexString.match(/.{1,2}/g).map(byte => parseInt(byte, 16)));
 
 const toHexString = bytes =>
-  bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
+    bytes.reduce((str, byte) => str + byte.toString(16).padStart(2, '0'), '');
 
 
 describe("EdDSA js test", function () {
@@ -42,19 +42,19 @@ describe("EdDSA js test", function () {
         assert(F.eq(signature.R8[1], F.e("20125634407542493427571099944365246191501563803226486072348038614369379124499")));
         // console.log(Scalar.toString(signature.S));
         assert(Scalar.eq(signature.S, Scalar.e("2129243915978267980511515511350111723623685317644064470882297086073041379651")));
-        
+
         const pSignature = eddsa.packSignature(signature);
 
         // console.log(toHexString(pSignature));
-        assert.equal(toHexString(pSignature), ""+
-            "138501d9e734e73f485269bcdc29a9ef2da3fac2f5c9653761d0364f95b47eac"+
+        assert.equal(toHexString(pSignature), "" +
+            "138501d9e734e73f485269bcdc29a9ef2da3fac2f5c9653761d0364f95b47eac" +
             "43e1a02b56ff3dacfdac040f3e8c2023dc259ba3f6880ca8ad246b4bfe1bb504");
 
         const uSignature = eddsa.unpackSignature(pSignature);
         assert(eddsa.verifyPedersen(msgBuf, uSignature, pubKey));
 
     });
-    
+
     it("Sign (using Mimc7) a single 10 bytes from 0 to 9", () => {
         const F = eddsa.babyJub.F;
         const msgBuf = fromHexString("000102030405060708090000");
@@ -79,12 +79,12 @@ describe("EdDSA js test", function () {
         assert(F.eq(signature.R8[1], F.e("15383486972088797283337779941324724402501462225528836549661220478783371668959")));
         // console.log(Scalar.toString(signature.S));
         assert(Scalar.eq(signature.S, Scalar.e("2523202440825208709475937830811065542425109372212752003460238913256192595070")));
-        
+
         const pSignature = eddsa.packSignature(signature);
 
         // console.log(toHexString(pSignature));
-        assert.equal(toHexString(pSignature), ""+
-            "dfedb4315d3f2eb4de2d3c510d7a987dcab67089c8ace06308827bf5bcbe02a2"+
+        assert.equal(toHexString(pSignature), "" +
+            "dfedb4315d3f2eb4de2d3c510d7a987dcab67089c8ace06308827bf5bcbe02a2" +
             "7ed40dab29bf993c928e789d007387998901a24913d44fddb64b1f21fc149405");
 
         const uSignature = eddsa.unpackSignature(pSignature);
@@ -116,12 +116,12 @@ describe("EdDSA js test", function () {
         assert(F.eq(signature.R8[1], F.e("15383486972088797283337779941324724402501462225528836549661220478783371668959")));
         // console.log(Scalar.toString(signature.S));
         assert(Scalar.eq(signature.S, Scalar.e("1672775540645840396591609181675628451599263765380031905495115170613215233181")));
-        
+
         const pSignature = eddsa.packSignature(signature);
 
         // console.log(toHexString(pSignature));
-        assert.equal(toHexString(pSignature), ""+
-            "dfedb4315d3f2eb4de2d3c510d7a987dcab67089c8ace06308827bf5bcbe02a2"+
+        assert.equal(toHexString(pSignature), "" +
+            "dfedb4315d3f2eb4de2d3c510d7a987dcab67089c8ace06308827bf5bcbe02a2" +
             "9d043ece562a8f82bfc0adb640c0107a7d3a27c1c7c1a6179a0da73de5c1b203");
 
         const uSignature = eddsa.unpackSignature(pSignature);
@@ -153,15 +153,37 @@ describe("EdDSA js test", function () {
         assert(F.eq(signature.R8[1], F.e("15383486972088797283337779941324724402501462225528836549661220478783371668959")));
         // console.log(Scalar.toString(signature.S));
         assert(Scalar.eq(signature.S, Scalar.e("1868336918738674306327358602987493427631678603535639134028485964115448322340")));
-        
+
         const pSignature = eddsa.packSignature(signature);
 
         // console.log(toHexString(pSignature));
-        assert.equal(toHexString(pSignature), ""+
-            "dfedb4315d3f2eb4de2d3c510d7a987dcab67089c8ace06308827bf5bcbe02a2"+
+        assert.equal(toHexString(pSignature), "" +
+            "dfedb4315d3f2eb4de2d3c510d7a987dcab67089c8ace06308827bf5bcbe02a2" +
             "24599218a1c2e5290bf58b2eec37bfec1395179ed5e817f10f86c9e7f3702104");
 
         const uSignature = eddsa.unpackSignature(pSignature);
         assert(eddsa.verifyMiMCSponge(msg, uSignature, pubKey));
     });
+
+    it("Reject a signature with a negative S", function () {
+        this.timeout(5000);
+        const msgBuf = fromHexString("000102030405060708090000");
+        const msg = eddsa.babyJub.F.e(Scalar.fromRprLE(msgBuf, 0));
+
+        const prvKey = Buffer.from("0001020304050607080900010203040506070809000102030405060708090001", "hex");
+        const pubKey = eddsa.prv2pub(prvKey);
+
+        const signature = eddsa.signPoseidon(prvKey, msg);
+        assert(eddsa.verifyPoseidon(msg, signature, pubKey));
+
+        // Modular negation: subOrder - S is the additive inverse of S in the
+        // scalar subgroup, and stays inside the [0, subOrder) bounds check.
+        const negSig = { R8: signature.R8, S: Scalar.sub(eddsa.babyJub.subOrder, signature.S) };
+        assert.isFalse(eddsa.verifyPoseidon(msg, negSig, pubKey));
+
+        // Raw negative BigInt S — mulPointEscalar must not loop forever.
+        const rawNegSig = { R8: signature.R8, S: Scalar.neg(signature.S) };
+        assert.isFalse(eddsa.verifyPoseidon(msg, rawNegSig, pubKey));
+    });
+
 });


### PR DESCRIPTION
## Problem

`BabyJub.mulPointEscalar(P, e)` assumed `e >= 0`. Passing a negative `BigInt` made the `while (!Scalar.isZero(rem))` loop spin forever -- right-shifting a negative scalar never reaches zero.

This was reachable through EdDSA verification: the `verify*` functions checked `S >= subOrder` but did not check `S >= 0`, so a malformed signature with a raw negative `S` made `verifyPoseidon` / `verifyMiMC` / `verifyMiMCSponge` / `verifyPedersen` hang inside scalar mult instead of returning `false`. Verifier DoS, not a forgery.

## Fix

Two layers:

**1. Make the primitive total over `ℤ` ([src/babyjub.js](src/babyjub.js)).**
If `e < 0`, normalize to `[-e]·(-P)` before the double-and-add loop. On twisted Edwards, `-(x, y) = (-x, y)`, so the rewrite is one field negation and is universally correct (works for any point, in or out of subgroup -- important because `inSubgroup` itself calls `mulPointEscalar` on potentially-cofactor points, where reducing `e mod L` would silently give the wrong answer).

**2. Reject malformed signatures at the API boundary ([src/eddsa.js](src/eddsa.js)).**
Symmetric lower-bound check `if (Scalar.lt(sig.S, Scalar.e(0))) return false;` added to all four `verify*` functions, paired with the existing `S >= subOrder` upper-bound check. Negative `S` is rejected before any scalar mult runs.

Layer 1 closes the foot-gun for *every* caller of `mulPointEscalar` (current and future). Layer 2 is defense-in-depth at the EdDSA boundary -- faster rejection and clearer intent.

## Test

Added "Reject a signature with a negative S" in [test/eddsa.js](test/eddsa.js), covering both:

- **Modular negation**: `S' = subOrder - S` -- stays in `[0, subOrder)` and passes the bounds check, so it goes through scalar mult; verification correctly returns `false` because the equation doesn't hold.
- **Raw negative**: `S' = -S` -- must be rejected by the new bounds check *before* `mulPointEscalar` is called. The test enforces this by monkey-patching `eddsa.babyJub.mulPointEscalar` to throw; if the bounds check ever regresses and verification falls through, the test fails loudly.

All existing tests still pass.

## Notes

- The existing upper-bound check uses a mix of `Scalar.geq` (Pedersen) and native `>=` (others). The new lower-bound check uses `Scalar.lt` consistently. Happy to also normalize the upper-bound style if preferred.
- A small amount of whitespace/formatting cleanup is included in the same diff. Can be split into a separate commit on request.
